### PR TITLE
feat: implement Aletheia PBT improvements (Phase 1-6)

### DIFF
--- a/src/cli/main.mbt
+++ b/src/cli/main.mbt
@@ -383,12 +383,16 @@ fn analyze_packages(path : String) -> Array[PackageAnalysis] {
     let roundtrips = @patterns.find_round_trips(function_names)
     let idempotents = @patterns.find_idempotent_functions(function_names)
     let producers = @patterns.find_producer_consumer(function_names)
+    let invariants = @patterns.find_invariant_functions(function_names)
+    let oracles = @patterns.find_oracle_candidates(function_names)
     Array::push(results, {
       path: package_dir,
       functions,
       roundtrips,
       idempotents,
       producers,
+      invariants,
+      oracles,
     })
     i = i + 1
   }
@@ -402,6 +406,8 @@ priv struct PackageAnalysis {
   roundtrips : Array[@patterns.PatternCandidate]
   idempotents : Array[@patterns.PatternCandidate]
   producers : Array[@patterns.PatternCandidate]
+  invariants : Array[@patterns.PatternCandidate]
+  oracles : Array[@patterns.PatternCandidate]
 }
 
 ///|
@@ -444,6 +450,17 @@ fn describe_pattern(
       describe_function_name(functions, producer) +
       " -> " +
       describe_function_name(functions, consumer)
+    @patterns.Invariant(func, inv_type) =>
+      "Invariant: " +
+      describe_function_name(functions, func) +
+      " (" +
+      inv_type +
+      ")"
+    @patterns.Oracle(implementation, oracle) =>
+      "Oracle: " +
+      describe_function_name(functions, implementation) +
+      " vs " +
+      describe_function_name(functions, oracle)
   }
 }
 
@@ -487,6 +504,27 @@ fn pattern_to_json(
           json_string(function_signature_or_empty(functions, consumer)),
         ),
       ])
+    @patterns.Invariant(func, inv_type) =>
+      json_object([
+        ("kind", json_string("invariant")),
+        ("function", json_string(func)),
+        ("invariant_type", json_string(inv_type)),
+        ("signature", json_string(function_signature_or_empty(functions, func))),
+      ])
+    @patterns.Oracle(implementation, oracle) =>
+      json_object([
+        ("kind", json_string("oracle")),
+        ("implementation", json_string(implementation)),
+        ("oracle", json_string(oracle)),
+        (
+          "implementation_signature",
+          json_string(function_signature_or_empty(functions, implementation)),
+        ),
+        (
+          "oracle_signature",
+          json_string(function_signature_or_empty(functions, oracle)),
+        ),
+      ])
   }
 }
 
@@ -523,6 +561,14 @@ fn format_analysis_text(
     result = result +
       "Producer-Consumer patterns: " +
       int_to_string(pkg.producers.length()) +
+      "\n"
+    result = result +
+      "Invariant patterns: " +
+      int_to_string(pkg.invariants.length()) +
+      "\n"
+    result = result +
+      "Oracle patterns: " +
+      int_to_string(pkg.oracles.length()) +
       "\n"
     if explain {
       result = result + "Functions:\n"
@@ -591,6 +637,44 @@ fn format_analysis_text(
           j = j + 1
         }
       }
+      result = result + "Invariant details:\n"
+      if pkg.invariants.length() == 0 {
+        result = result + "  (none)\n"
+      } else {
+        let mut j = 0
+        while j < pkg.invariants.length() {
+          match pkg.invariants[j] {
+            @patterns.Invariant(func, inv_type) =>
+              result = result +
+                "  - " +
+                describe_function_name(pkg.functions, func) +
+                " (" +
+                inv_type +
+                ")\n"
+            _ => ()
+          }
+          j = j + 1
+        }
+      }
+      result = result + "Oracle details:\n"
+      if pkg.oracles.length() == 0 {
+        result = result + "  (none)\n"
+      } else {
+        let mut j = 0
+        while j < pkg.oracles.length() {
+          match pkg.oracles[j] {
+            @patterns.Oracle(implementation, oracle) =>
+              result = result +
+                "  - " +
+                describe_function_name(pkg.functions, implementation) +
+                " vs " +
+                describe_function_name(pkg.functions, oracle) +
+                "\n"
+            _ => ()
+          }
+          j = j + 1
+        }
+      }
     }
     i = i + 1
   }
@@ -621,6 +705,8 @@ fn format_analysis_json(
       ("round_trip_count", json_number(pkg.roundtrips.length())),
       ("idempotent_count", json_number(pkg.idempotents.length())),
       ("producer_consumer_count", json_number(pkg.producers.length())),
+      ("invariant_count", json_number(pkg.invariants.length())),
+      ("oracle_count", json_number(pkg.oracles.length())),
     ]
     if explain {
       let functions_json : Array[String] = []
@@ -657,10 +743,26 @@ fn format_analysis_json(
         Array::push(producer_json, pattern_to_json(pkg.functions, pat))
         j = j + 1
       }
+      let invariant_json : Array[String] = []
+      let mut j = 0
+      while j < pkg.invariants.length() {
+        let pat = pkg.invariants[j]
+        Array::push(invariant_json, pattern_to_json(pkg.functions, pat))
+        j = j + 1
+      }
+      let oracle_json : Array[String] = []
+      let mut j = 0
+      while j < pkg.oracles.length() {
+        let pat = pkg.oracles[j]
+        Array::push(oracle_json, pattern_to_json(pkg.functions, pat))
+        j = j + 1
+      }
       Array::push(pairs, ("functions", json_array(functions_json)))
       Array::push(pairs, ("round_trips", json_array(roundtrip_json)))
       Array::push(pairs, ("idempotents", json_array(idempotent_json)))
       Array::push(pairs, ("producer_consumers", json_array(producer_json)))
+      Array::push(pairs, ("invariants", json_array(invariant_json)))
+      Array::push(pairs, ("oracles", json_array(oracle_json)))
     }
     Array::push(package_jsons, json_object(pairs))
     i = i + 1
@@ -1095,6 +1197,16 @@ fn infer_default_type(
           Some(func) => type_name_from_function(func)
           None => None
         }
+      @patterns.Invariant(func, _) =>
+        match find_function_meta(functions, func) {
+          Some(func) => type_name_from_function(func)
+          None => None
+        }
+      @patterns.Oracle(implementation, _) =>
+        match find_function_meta(functions, implementation) {
+          Some(func) => type_name_from_function(func)
+          None => None
+        }
     }
     match type_name {
       Some(t) =>
@@ -1155,6 +1267,8 @@ fn build_generate_report(
   let roundtrips = @patterns.find_round_trips(function_names)
   let idempotents = @patterns.find_idempotent_functions(function_names)
   let producers = @patterns.find_producer_consumer(function_names)
+  let invariants = @patterns.find_invariant_functions(function_names)
+  let oracles = @patterns.find_oracle_candidates(function_names)
 
   // すべてのパターンを統合
   let mut all_patterns : Array[@patterns.PatternCandidate] = []
@@ -1171,6 +1285,16 @@ fn build_generate_report(
   let mut i = 0
   while i < producers.length() {
     all_patterns = append_pattern(all_patterns, producers[i])
+    i = i + 1
+  }
+  let mut i = 0
+  while i < invariants.length() {
+    all_patterns = append_pattern(all_patterns, invariants[i])
+    i = i + 1
+  }
+  let mut i = 0
+  while i < oracles.length() {
+    all_patterns = append_pattern(all_patterns, oracles[i])
     i = i + 1
   }
   let known_impls = collect_arbitrary_impls_from_packages(package_dirs)

--- a/src/generator/pkg.generated.mbti
+++ b/src/generator/pkg.generated.mbti
@@ -8,9 +8,17 @@ import(
 // Values
 pub fn build_pbt_document(String, String, Array[@patterns.PatternCandidate], String) -> PbtDocument
 
+pub fn generate_counterexample_section() -> String
+
+pub fn generate_frequency_generator_template(String, Array[(Int, String)]) -> String
+
 pub fn generate_idempotent_test(String, String) -> GeneratedTest
 
+pub fn generate_invariant_test(String, String, String) -> GeneratedTest
+
 pub fn generate_mbt_md_section(Array[GeneratedTest]) -> String
+
+pub fn generate_oracle_test(String, String, String) -> GeneratedTest
 
 pub fn generate_pbt_md(PbtDocument) -> String
 
@@ -19,6 +27,8 @@ pub fn generate_pbt_targets_md(PbtDocument) -> String
 pub fn generate_producer_consumer_test(String, String, String) -> GeneratedTest
 
 pub fn generate_round_trip_test(String, String, String) -> GeneratedTest
+
+pub fn generate_test_with_stats(String, String, String, Array[(String, String)]) -> GeneratedTest
 
 pub fn generated_block_end() -> String
 
@@ -50,6 +60,8 @@ pub enum PatternKind {
   RoundTrip
   Idempotent
   ProducerConsumer
+  Invariant
+  Oracle
 }
 
 pub struct PbtDocument {

--- a/src/generator/property_gen.mbt
+++ b/src/generator/property_gen.mbt
@@ -160,6 +160,8 @@ pub enum PatternKind {
   RoundTrip
   Idempotent
   ProducerConsumer
+  Invariant
+  Oracle
 }
 
 ///|
@@ -210,6 +212,10 @@ pub fn pattern_to_test(
     @patterns.Idempotent(func) => generate_idempotent_test(func, type_name)
     @patterns.ProducerConsumer(producer, consumer) =>
       generate_producer_consumer_test(producer, consumer, type_name)
+    @patterns.Invariant(func, inv_type) =>
+      generate_invariant_test(func, inv_type, type_name)
+    @patterns.Oracle(implementation, oracle) =>
+      generate_oracle_test(implementation, oracle, type_name)
   }
 }
 
@@ -239,6 +245,206 @@ pub fn generate_producer_consumer_test(
 }
 
 ///|
+/// 不変条件プロパティテストを生成
+pub fn generate_invariant_test(
+  func : String,
+  inv_type : String,
+  type_name : String,
+) -> GeneratedTest {
+  let test_name = "prop_" + func + "_invariant_" + inv_type.to_lower()
+  let (assertion, description) = match inv_type {
+    "LengthPreserving" =>
+      (
+        "assert_eq(" + func + "(x).length(), x.length())",
+        "Invariant property: " + func + " preserves length",
+      )
+    "LengthDecreasing" =>
+      (
+        "assert_true(" + func + "(x).length() <= x.length())",
+        "Invariant property: " + func + " does not increase length",
+      )
+    "LengthIncreasing" =>
+      (
+        "assert_true(" + func + "(x).length() >= x.length())",
+        "Invariant property: " + func + " does not decrease length",
+      )
+    "OrderPreserving" =>
+      (
+        "// Order of elements is preserved by " + func,
+        "Invariant property: " + func + " preserves element order",
+      )
+    "ContentPreserving" =>
+      (
+        "assert_eq(" +
+        func +
+        "(x).iter().fold(init=0, fn(acc, e) { acc + e.hash() }), x.iter().fold(init=0, fn(acc, e) { acc + e.hash() }))",
+        "Invariant property: " + func + " preserves content (same elements)",
+      )
+    _ =>
+      (
+        "// TODO: Define invariant for " + inv_type,
+        "Invariant property: " + func + " maintains " + inv_type,
+      )
+  }
+  let test_code = "test \"" +
+    test_name +
+    "\" {\n  let samples : Array[" +
+    type_name +
+    "] = @quickcheck.samples(100)\n  for x in samples {\n    " +
+    assertion +
+    "\n  }\n}"
+  { name: test_name, code: test_code, description, fence: "mbt nocheck" }
+}
+
+///|
+/// オラクルプロパティテストを生成
+pub fn generate_oracle_test(
+  implementation : String,
+  oracle : String,
+  type_name : String,
+) -> GeneratedTest {
+  let test_name = "prop_" + implementation + "_vs_" + oracle + "_oracle"
+  let test_code = "test \"" +
+    test_name +
+    "\" {\n  let samples : Array[" +
+    type_name +
+    "] = @quickcheck.samples(100)\n  for x in samples {\n    assert_eq(" +
+    implementation +
+    "(x), " +
+    oracle +
+    "(x))\n  }\n}"
+  {
+    name: test_name,
+    code: test_code,
+    description: "Oracle property: " +
+    implementation +
+    " should produce the same result as " +
+    oracle,
+    fence: "mbt nocheck",
+  }
+}
+
+///|
+/// 頻度分布付きジェネレータテンプレートを生成
+pub fn generate_frequency_generator_template(
+  type_name : String,
+  distribution : Array[(Int, String)],
+) -> String {
+  let mut result = "fn gen_" +
+    type_name.to_lower() +
+    "() -> @pbt.Gen[" +
+    type_name +
+    "] {\n"
+  result = result + "  @pbt.frequency([\n"
+  let mut i = 0
+  while i < distribution.length() {
+    let (weight, variant) = distribution[i]
+    result = result +
+      "    (" +
+      weight.to_string() +
+      ", @pbt.Gen::constant(" +
+      variant +
+      "))"
+    if i < distribution.length() - 1 {
+      result = result + ","
+    }
+    result = result + "\n"
+    i = i + 1
+  }
+  result = result + "  ])\n}"
+  result
+}
+
+///|
+/// 統計付きテストを生成
+pub fn generate_test_with_stats(
+  test_name : String,
+  gen_code : String,
+  property_code : String,
+  classifications : Array[(String, String)],
+) -> GeneratedTest {
+  let mut classify_code = ""
+  let mut i = 0
+  while i < classifications.length() {
+    let (label, condition) = classifications[i]
+    if i == 0 {
+      classify_code = "    let label = if " +
+        condition +
+        " { Some(\"" +
+        label +
+        "\") }"
+    } else {
+      classify_code = classify_code +
+        " else if " +
+        condition +
+        " { Some(\"" +
+        label +
+        "\") }"
+    }
+    i = i + 1
+  }
+  if classifications.length() > 0 {
+    classify_code = classify_code + " else { None }\n"
+  }
+  let test_code = "test \"" +
+    test_name +
+    "\" {\n  let gen = " +
+    gen_code +
+    "\n  let result = @pbt.check_with_stats(gen, fn(x) {\n" +
+    classify_code +
+    "    " +
+    property_code +
+    "\n    (Ok(()), label)\n  })\n  match result.stats {\n    Some(stats) => println(stats.to_string())\n    None => ()\n  }\n  assert_true(result.passed)\n}"
+  {
+    name: test_name,
+    code: test_code,
+    description: "Property test with statistical classification",
+    fence: "mbt nocheck",
+  }
+}
+
+///|
+/// 反例ログセクションを生成
+pub fn generate_counterexample_section() -> String {
+  "## Counterexample Logging\n\n" +
+  "When a property test fails, the following information is logged:\n\n" +
+  "- **Original value**: The first value that caused the failure\n" +
+  "- **Shrunk value**: The minimal value that still causes the failure (if shrinking is enabled)\n" +
+  "- **Test case index**: Which test case failed\n" +
+  "- **Size parameter**: The size used to generate the failing value\n" +
+  "- **Random seed**: The seed used for reproducibility\n\n" +
+  "To reproduce a failure, use the same seed:\n\n" +
+  "```mbt nocheck\n" +
+  "let config = @pbt.CheckConfig::new(cases=100, max_size=30, seed=<SEED>, shrink_limit=100)\n" +
+  "@pbt.check(gen, prop, config~)\n" +
+  "```\n"
+}
+
+///|
+fn string_to_lower(s : String) -> String {
+  let chars = s.to_array()
+  let mut result = ""
+  let mut i = 0
+  while i < chars.length() {
+    let c = chars[i]
+    let code = c.to_int()
+    if code >= 65 && code <= 90 {
+      // A-Z -> a-z
+      result = result + Char::from_int(code + 32).to_string()
+    } else {
+      result = result + c.to_string()
+    }
+    i = i + 1
+  }
+  result
+}
+
+///|
+fn String::to_lower(self : String) -> String {
+  string_to_lower(self)
+}
+
+///|
 /// PatternCandidate を DetectedPattern に変換
 fn pattern_to_detected(pattern : @patterns.PatternCandidate) -> DetectedPattern {
   match pattern {
@@ -252,6 +458,10 @@ fn pattern_to_detected(pattern : @patterns.PatternCandidate) -> DetectedPattern 
         functions: [producer, consumer],
         type_info: "T",
       }
+    @patterns.Invariant(func, inv_type) =>
+      { kind: Invariant, functions: [func, inv_type], type_info: "T" }
+    @patterns.Oracle(implementation, oracle) =>
+      { kind: Oracle, functions: [implementation, oracle], type_info: "T" }
   }
 }
 
@@ -263,6 +473,10 @@ fn pattern_sort_key(pattern : @patterns.PatternCandidate) -> String {
     @patterns.Idempotent(func) => "2_idempotent:" + func
     @patterns.ProducerConsumer(producer, consumer) =>
       "3_producer_consumer:" + producer + ":" + consumer
+    @patterns.Invariant(func, inv_type) =>
+      "4_invariant:" + func + ":" + inv_type
+    @patterns.Oracle(implementation, oracle) =>
+      "5_oracle:" + implementation + ":" + oracle
   }
 }
 
@@ -351,6 +565,8 @@ fn filter_patterns_by_kind(
       RoundTrip => pattern.kind is RoundTrip
       Idempotent => pattern.kind is Idempotent
       ProducerConsumer => pattern.kind is ProducerConsumer
+      Invariant => pattern.kind is Invariant
+      Oracle => pattern.kind is Oracle
     }
     if matches {
       result = append_detected(result, pattern)
@@ -406,6 +622,8 @@ pub fn generate_pbt_md(doc : PbtDocument) -> String {
   let roundtrips = filter_by_name_suffix(doc.test_cases, "roundtrip")
   let idempotents = filter_by_name_suffix(doc.test_cases, "idempotent")
   let pipelines = filter_by_name_suffix(doc.test_cases, "pipeline")
+  let invariants = filter_by_name_suffix(doc.test_cases, "invariant")
+  let oracles = filter_by_name_suffix(doc.test_cases, "oracle")
   if roundtrips.length() > 0 {
     result = result + "## Round-Trip Properties\n\n"
     let mut i = 0
@@ -439,6 +657,28 @@ pub fn generate_pbt_md(doc : PbtDocument) -> String {
       i = i + 1
     }
   }
+  if invariants.length() > 0 {
+    result = result + "## Invariant Properties\n\n"
+    let mut i = 0
+    while i < invariants.length() {
+      let t = invariants[i]
+      result = result + "### " + t.name + "\n\n"
+      result = result + t.description + "\n\n"
+      result = result + "```" + t.fence + "\n" + t.code + "\n```\n\n"
+      i = i + 1
+    }
+  }
+  if oracles.length() > 0 {
+    result = result + "## Oracle Properties\n\n"
+    let mut i = 0
+    while i < oracles.length() {
+      let t = oracles[i]
+      result = result + "### " + t.name + "\n\n"
+      result = result + t.description + "\n\n"
+      result = result + "```" + t.fence + "\n" + t.code + "\n```\n\n"
+      i = i + 1
+    }
+  }
   result
 }
 
@@ -459,6 +699,8 @@ pub fn generate_pbt_targets_md(doc : PbtDocument) -> String {
   let roundtrips = filter_patterns_by_kind(doc.patterns, RoundTrip)
   let idempotents = filter_patterns_by_kind(doc.patterns, Idempotent)
   let pipelines = filter_patterns_by_kind(doc.patterns, ProducerConsumer)
+  let invariants = filter_patterns_by_kind(doc.patterns, Invariant)
+  let oracles = filter_patterns_by_kind(doc.patterns, Oracle)
   if roundtrips.length() > 0 {
     result = result + "## Round-Trip Targets\n\n"
     let mut i = 0
@@ -498,6 +740,40 @@ pub fn generate_pbt_targets_md(doc : PbtDocument) -> String {
           "- `" +
           p.functions[0] +
           "` -> `" +
+          p.functions[1] +
+          "`\n"
+      }
+      i = i + 1
+    }
+    result = result + "\n"
+  }
+  if invariants.length() > 0 {
+    result = result + "## Invariant Targets\n\n"
+    let mut i = 0
+    while i < invariants.length() {
+      let p = invariants[i]
+      if p.functions.length() >= 2 {
+        result = result +
+          "- `" +
+          p.functions[0] +
+          "` (" +
+          p.functions[1] +
+          ")\n"
+      }
+      i = i + 1
+    }
+    result = result + "\n"
+  }
+  if oracles.length() > 0 {
+    result = result + "## Oracle Targets\n\n"
+    let mut i = 0
+    while i < oracles.length() {
+      let p = oracles[i]
+      if p.functions.length() >= 2 {
+        result = result +
+          "- `" +
+          p.functions[0] +
+          "` vs `" +
           p.functions[1] +
           "`\n"
       }

--- a/src/patterns/patterns.mbt
+++ b/src/patterns/patterns.mbt
@@ -12,6 +12,31 @@ pub enum PatternCandidate {
   Idempotent(String) // function_name
   /// Producer-Consumer: 型による連鎖
   ProducerConsumer(String, String) // (producer, consumer)
+  /// 不変条件: 操作前後で保存される性質
+  Invariant(String, String) // (func_name, invariant_type)
+  /// オラクル: 実装と参照実装の比較
+  Oracle(String, String) // (implementation, oracle)
+}
+
+///|
+/// 不変条件の種類
+pub enum InvariantType {
+  LengthPreserving
+  LengthDecreasing
+  LengthIncreasing
+  OrderPreserving
+  ContentPreserving
+}
+
+///|
+pub fn InvariantType::to_string(self : InvariantType) -> String {
+  match self {
+    LengthPreserving => "LengthPreserving"
+    LengthDecreasing => "LengthDecreasing"
+    LengthIncreasing => "LengthIncreasing"
+    OrderPreserving => "OrderPreserving"
+    ContentPreserving => "ContentPreserving"
+  }
 }
 
 ///|
@@ -153,6 +178,201 @@ pub fn make_producer_consumer(
 }
 
 ///|
+/// Invariantパターンを構築するヘルパー関数
+pub fn make_invariant(func : String, inv_type : String) -> PatternCandidate {
+  Invariant(func, inv_type)
+}
+
+///|
+/// Oracleパターンを構築するヘルパー関数
+pub fn make_oracle(
+  implementation : String,
+  oracle : String,
+) -> PatternCandidate {
+  Oracle(implementation, oracle)
+}
+
+///|
+/// 不変条件パターンを検出
+/// push/pop, insert/remove などの操作で保存される性質を検出
+pub fn find_invariant_functions(
+  function_names : Array[String],
+) -> Array[PatternCandidate] {
+  let results : Array[PatternCandidate] = []
+
+  // 不変条件タイプごとのキーワード
+  let length_preserving = ["map", "reverse", "shuffle", "swap", "rotate"]
+  let length_decreasing = ["pop", "remove", "delete", "drop", "take", "filter"]
+  let length_increasing = ["push", "insert", "add", "append", "prepend"]
+  let order_preserving = ["map", "filter"]
+  let content_preserving = ["sort", "reverse", "shuffle", "rotate"]
+  let mut i = 0
+  while i < Array::length(function_names) {
+    let name = function_names[i]
+
+    // LengthPreserving
+    let mut j = 0
+    while j < Array::length(length_preserving) {
+      let keyword = length_preserving[j]
+      if name.contains(keyword) {
+        Array::push(results, Invariant(name, "LengthPreserving"))
+      }
+      j = j + 1
+    }
+
+    // LengthDecreasing
+    let mut j = 0
+    while j < Array::length(length_decreasing) {
+      let keyword = length_decreasing[j]
+      if name.contains(keyword) {
+        Array::push(results, Invariant(name, "LengthDecreasing"))
+      }
+      j = j + 1
+    }
+
+    // LengthIncreasing
+    let mut j = 0
+    while j < Array::length(length_increasing) {
+      let keyword = length_increasing[j]
+      if name.contains(keyword) {
+        Array::push(results, Invariant(name, "LengthIncreasing"))
+      }
+      j = j + 1
+    }
+
+    // OrderPreserving (map, filter は順序を保存)
+    let mut j = 0
+    while j < Array::length(order_preserving) {
+      let keyword = order_preserving[j]
+      if name.contains(keyword) &&
+        !has_pattern(results, name, "OrderPreserving") {
+        Array::push(results, Invariant(name, "OrderPreserving"))
+      }
+      j = j + 1
+    }
+
+    // ContentPreserving (sort, reverse などは内容を保存)
+    let mut j = 0
+    while j < Array::length(content_preserving) {
+      let keyword = content_preserving[j]
+      if name.contains(keyword) &&
+        !has_pattern(results, name, "ContentPreserving") {
+        Array::push(results, Invariant(name, "ContentPreserving"))
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  results
+}
+
+///|
+/// 重複チェック用ヘルパー
+fn has_pattern(
+  patterns : Array[PatternCandidate],
+  func : String,
+  inv_type : String,
+) -> Bool {
+  let mut i = 0
+  while i < patterns.length() {
+    match patterns[i] {
+      Invariant(f, t) => if f == func && t == inv_type { return true }
+      _ => ()
+    }
+    i = i + 1
+  }
+  false
+}
+
+///|
+/// オラクルパターンを検出
+/// カスタム実装と標準ライブラリの対応を検出
+pub fn find_oracle_candidates(
+  function_names : Array[String],
+) -> Array[PatternCandidate] {
+  let results : Array[PatternCandidate] = []
+
+  // カスタム実装を示すプレフィックス
+  let custom_prefixes = [
+    "my_", "custom_", "fast_", "optimized_", "simple_", "naive_",
+  ]
+
+  // 標準ライブラリ関数との対応付け
+  let std_functions = [
+    "sort", "reverse", "map", "filter", "fold", "reduce", "find", "contains", "length",
+    "concat", "join", "split", "trim", "parse", "format",
+  ]
+  let mut i = 0
+  while i < Array::length(function_names) {
+    let name = function_names[i]
+
+    // プレフィックス付きの関数を探す
+    let mut j = 0
+    while j < Array::length(custom_prefixes) {
+      let prefix = custom_prefixes[j]
+      if name.has_prefix(prefix) {
+        // プレフィックスを除いた名前を取得
+        let base_name = remove_prefix(name, prefix)
+
+        // 対応する標準関数があるか確認
+        let mut k = 0
+        while k < Array::length(std_functions) {
+          let std_func = std_functions[k]
+          if base_name.contains(std_func) {
+            // 標準関数が関数リストにあるか確認
+            let mut m = 0
+            while m < Array::length(function_names) {
+              let other = function_names[m]
+              if other != name &&
+                other.contains(std_func) &&
+                !has_custom_prefix(other, custom_prefixes) {
+                Array::push(results, Oracle(name, other))
+              }
+              m = m + 1
+            }
+          }
+          k = k + 1
+        }
+      }
+      j = j + 1
+    }
+    i = i + 1
+  }
+  results
+}
+
+///|
+/// プレフィックスを除去
+fn remove_prefix(s : String, prefix : String) -> String {
+  if s.has_prefix(prefix) {
+    let chars = s.to_array()
+    let prefix_len = prefix.length()
+    let mut result = ""
+    let mut i = prefix_len
+    while i < chars.length() {
+      result = result + chars[i].to_string()
+      i = i + 1
+    }
+    result
+  } else {
+    s
+  }
+}
+
+///|
+/// カスタムプレフィックスを持つかチェック
+fn has_custom_prefix(name : String, prefixes : Array[String]) -> Bool {
+  let mut i = 0
+  while i < prefixes.length() {
+    if name.has_prefix(prefixes[i]) {
+      return true
+    }
+    i = i + 1
+  }
+  false
+}
+
+///|
 /// テスト
 test "find_round_trips_simple" {
   let names = ["encode_data", "decode_data", "to_string", "from_string"]
@@ -200,4 +420,70 @@ test "find_idempotent_functions_empty" {
   let names : Array[String] = []
   let results = find_idempotent_functions(names)
   inspect(results.length(), content="0")
+}
+
+///|
+test "find_invariant_functions_length_preserving" {
+  let names = ["map_values", "reverse_list", "shuffle_array"]
+  let results = find_invariant_functions(names)
+  // map_values: LengthPreserving + OrderPreserving
+  // reverse_list: LengthPreserving + ContentPreserving
+  // shuffle_array: LengthPreserving + ContentPreserving
+  inspect(results.length() > 0, content="true")
+}
+
+///|
+test "find_invariant_functions_length_changing" {
+  let names = ["push_item", "pop_item", "filter_list"]
+  let results = find_invariant_functions(names)
+  // push_item: LengthIncreasing
+  // pop_item: LengthDecreasing
+  // filter_list: LengthDecreasing + OrderPreserving
+  inspect(results.length() > 0, content="true")
+}
+
+///|
+test "find_invariant_functions_empty" {
+  let names : Array[String] = []
+  let results = find_invariant_functions(names)
+  inspect(results.length(), content="0")
+}
+
+///|
+test "find_oracle_candidates_simple" {
+  let names = ["my_sort", "sort", "custom_reverse", "reverse"]
+  let results = find_oracle_candidates(names)
+  // my_sort -> sort, custom_reverse -> reverse
+  inspect(results.length(), content="2")
+}
+
+///|
+test "find_oracle_candidates_no_match" {
+  let names = ["encode", "decode", "process"]
+  let results = find_oracle_candidates(names)
+  inspect(results.length(), content="0")
+}
+
+///|
+test "make_invariant_helper" {
+  let pattern = make_invariant("push", "LengthIncreasing")
+  match pattern {
+    Invariant(func, inv_type) => {
+      inspect(func, content="push")
+      inspect(inv_type, content="LengthIncreasing")
+    }
+    _ => inspect("fail", content="ok")
+  }
+}
+
+///|
+test "make_oracle_helper" {
+  let pattern = make_oracle("my_sort", "sort")
+  match pattern {
+    Oracle(implementation, oracle) => {
+      inspect(implementation, content="my_sort")
+      inspect(oracle, content="sort")
+    }
+    _ => inspect("fail", content="ok")
+  }
 }

--- a/src/patterns/pkg.generated.mbti
+++ b/src/patterns/pkg.generated.mbti
@@ -4,11 +4,19 @@ package "f4ah6o/aletheia/patterns"
 // Values
 pub fn find_idempotent_functions(Array[String]) -> Array[PatternCandidate]
 
+pub fn find_invariant_functions(Array[String]) -> Array[PatternCandidate]
+
+pub fn find_oracle_candidates(Array[String]) -> Array[PatternCandidate]
+
 pub fn find_producer_consumer(Array[String]) -> Array[PatternCandidate]
 
 pub fn find_round_trips(Array[String]) -> Array[PatternCandidate]
 
 pub fn make_idempotent(String) -> PatternCandidate
+
+pub fn make_invariant(String, String) -> PatternCandidate
+
+pub fn make_oracle(String, String) -> PatternCandidate
 
 pub fn make_producer_consumer(String, String) -> PatternCandidate
 
@@ -17,10 +25,21 @@ pub fn make_round_trip(String, String) -> PatternCandidate
 // Errors
 
 // Types and methods
+pub enum InvariantType {
+  LengthPreserving
+  LengthDecreasing
+  LengthIncreasing
+  OrderPreserving
+  ContentPreserving
+}
+pub fn InvariantType::to_string(Self) -> String
+
 pub enum PatternCandidate {
   RoundTrip(String, String)
   Idempotent(String)
   ProducerConsumer(String, String)
+  Invariant(String, String)
+  Oracle(String, String)
 }
 
 // Type aliases

--- a/src/pbt/check.mbt
+++ b/src/pbt/check.mbt
@@ -129,3 +129,251 @@ pub fn[T : Show] assert_check(
     Err(failure) => fail("\{label}: \{failure}")
   }
 }
+
+///|
+/// 統計エントリ
+pub struct StatEntry {
+  label : String
+  count : Int
+  percentage : Double
+} derive(Show)
+
+///|
+/// 統計情報
+pub struct Statistics {
+  entries : Array[StatEntry]
+  mut total : Int
+} derive(Show)
+
+///|
+pub fn Statistics::new() -> Statistics {
+  { entries: [], total: 0 }
+}
+
+///|
+pub fn Statistics::add_label(self : Statistics, label : String) -> Unit {
+  // 既存のラベルを探す
+  let mut i = 0
+  while i < self.entries.length() {
+    if self.entries[i].label == label {
+      self.entries[i] = {
+        label: self.entries[i].label,
+        count: self.entries[i].count + 1,
+        percentage: 0.0,
+      }
+      return
+    }
+    i = i + 1
+  }
+  // 新しいラベルを追加
+  self.entries.push({ label, count: 1, percentage: 0.0 })
+}
+
+///|
+pub fn Statistics::finalize(self : Statistics) -> Unit {
+  let total = self.total
+  if total == 0 {
+    return
+  }
+  let mut i = 0
+  while i < self.entries.length() {
+    let entry = self.entries[i]
+    self.entries[i] = {
+      label: entry.label,
+      count: entry.count,
+      percentage: entry.count.to_double() / total.to_double() * 100.0,
+    }
+    i = i + 1
+  }
+}
+
+///|
+pub fn Statistics::to_string(self : Statistics) -> String {
+  if self.entries.length() == 0 {
+    return "No statistics collected"
+  }
+  let mut result = "Statistics (total: " + self.total.to_string() + "):\n"
+  let mut i = 0
+  while i < self.entries.length() {
+    let entry = self.entries[i]
+    result = result +
+      "  " +
+      entry.label +
+      ": " +
+      entry.count.to_string() +
+      " (" +
+      format_percentage(entry.percentage) +
+      "%)\n"
+    i = i + 1
+  }
+  result
+}
+
+///|
+fn format_percentage(p : Double) -> String {
+  let int_part = p.to_int()
+  let frac_part = ((p - int_part.to_double()) * 10.0).to_int()
+  int_part.to_string() + "." + frac_part.to_string()
+}
+
+///|
+/// 統計付きチェック結果
+pub struct CheckResult[T] {
+  passed : Bool
+  failure : Failure?
+  stats : Statistics?
+} derive(Show)
+
+///|
+/// 分類付きプロパティを実行
+/// 条件に基づいてテストケースを分類し、統計を収集する
+pub fn[T] classify(
+  label : String,
+  condition : Bool,
+  prop : (T) -> Result[Unit, String],
+) -> (T) -> (Result[Unit, String], String?) {
+  fn(value : T) -> (Result[Unit, String], String?) {
+    let result = prop(value)
+    if condition {
+      (result, Some(label))
+    } else {
+      (result, None)
+    }
+  }
+}
+
+///|
+/// 値を収集してプロパティを実行
+/// 値を文字列に変換して統計を収集する
+pub fn[T, V : Show] collect(
+  value : V,
+  prop : (T) -> Result[Unit, String],
+) -> (T) -> (Result[Unit, String], String?) {
+  fn(input : T) -> (Result[Unit, String], String?) {
+    let result = prop(input)
+    (result, Some("\{value}"))
+  }
+}
+
+///|
+/// 統計付きチェックを実行
+pub fn[T : Show] check_with_stats(
+  gen : Gen[T],
+  prop : (T) -> (Result[Unit, String], String?),
+  config? : CheckConfig = CheckConfig::default(),
+  shrink? : (T) -> Iter[T],
+) -> CheckResult[T] {
+  let config = config
+  let cases = if config.cases < 0 { 0 } else { config.cases }
+  let max_size = if config.max_size < 0 { 0 } else { config.max_size }
+  let rs = @quickcheck/splitmix.new(seed=config.seed)
+  let stats = Statistics::new()
+  let mut i = 0
+  while i < cases {
+    let size = if i < max_size { i } else { max_size }
+    let value = (gen.run)(size, rs)
+    let (result, label_opt) = prop(value)
+    stats.total = stats.total + 1
+
+    // ラベルがあれば統計に追加
+    match label_opt {
+      Some(label) => stats.add_label(label)
+      None => ()
+    }
+    match result {
+      Ok(_) => ()
+      Err(msg) => {
+        let original = "\{value}"
+        let mut final_value = value
+        let mut final_msg = msg
+        let mut shrunk : String? = None
+        match shrink {
+          None => ()
+          Some(shrinker) => {
+            let (shrunk_value, shrunk_msg) = shrink_value_with_stats(
+              value,
+              final_msg,
+              fn(v) { prop(v).0 },
+              shrinker,
+              config.shrink_limit,
+            )
+            final_value = shrunk_value
+            final_msg = shrunk_msg
+            shrunk = Some("\{final_value}")
+          }
+        }
+        stats.finalize()
+        return {
+          passed: false,
+          failure: Some(Failure::{
+            case_index: i,
+            size,
+            seed: config.seed,
+            message: final_msg,
+            original,
+            shrunk,
+          }),
+          stats: Some(stats),
+        }
+      }
+    }
+    i = i + 1
+  }
+  stats.finalize()
+  { passed: true, failure: None, stats: Some(stats) }
+}
+
+///|
+fn[T] shrink_value_with_stats(
+  value : T,
+  message : String,
+  prop : (T) -> Result[Unit, String],
+  shrinker : (T) -> Iter[T],
+  limit : Int,
+) -> (T, String) {
+  if limit <= 0 {
+    return (value, message)
+  }
+  let mut current = value
+  let mut current_msg = message
+  let mut rounds = 0
+  while rounds < limit {
+    let mut found = false
+    for candidate in shrinker(current) {
+      match prop(candidate) {
+        Ok(_) => ()
+        Err(msg) => {
+          current = candidate
+          current_msg = msg
+          found = true
+          break
+        }
+      }
+    }
+    if not(found) {
+      break
+    }
+    rounds += 1
+  }
+  (current, current_msg)
+}
+
+///|
+/// 統計付きアサーション
+pub fn[T : Show] assert_check_with_stats(
+  label : String,
+  gen : Gen[T],
+  prop : (T) -> (Result[Unit, String], String?),
+  config? : CheckConfig = CheckConfig::default(),
+  shrink? : (T) -> Iter[T],
+) -> Unit raise {
+  let result = check_with_stats(gen, prop, config~, shrink?)
+  match result.stats {
+    Some(stats) => println(stats.to_string())
+    None => ()
+  }
+  match result.failure {
+    Some(failure) => fail("\{label}: \{failure}")
+    None => ()
+  }
+}

--- a/src/pbt/pkg.generated.mbti
+++ b/src/pbt/pkg.generated.mbti
@@ -9,11 +9,31 @@ import(
 // Values
 pub fn[T : Show] assert_check(String, Gen[T], (T) -> Result[Unit, String], config? : CheckConfig, shrink? : (T) -> Iter[T]) -> Unit raise
 
+pub fn[T : Show] assert_check_with_stats(String, Gen[T], (T) -> (Result[Unit, String], String?), config? : CheckConfig, shrink? : (T) -> Iter[T]) -> Unit raise
+
 pub fn[T : Show] check(Gen[T], (T) -> Result[Unit, String], config? : CheckConfig, shrink? : (T) -> Iter[T]) -> Result[Unit, Failure]
+
+pub fn[T : Show] check_with_stats(Gen[T], (T) -> (Result[Unit, String], String?), config? : CheckConfig, shrink? : (T) -> Iter[T]) -> CheckResult[T]
+
+pub fn[T] classify(String, Bool, (T) -> Result[Unit, String]) -> (T) -> (Result[Unit, String], String?)
+
+pub fn[T, V : Show] collect(V, (T) -> Result[Unit, String]) -> (T) -> (Result[Unit, String], String?)
+
+pub fn generate_shrink_template(String, Array[(String, String)]) -> String
 
 pub fn[T] shrink_array(Array[T]) -> Iter[Array[T]]
 
+pub fn shrink_bool(Bool) -> Iter[Bool]
+
+pub fn shrink_double(Double) -> Iter[Double]
+
 pub fn shrink_int(Int) -> Iter[Int]
+
+pub fn[T] shrink_option(T?, (T) -> Iter[T]) -> Iter[T?]
+
+pub fn shrink_string(String) -> Iter[String]
+
+pub fn[A, B] shrink_tuple2((A, B), (A) -> Iter[A], (B) -> Iter[B]) -> Iter[(A, B)]
 
 // Errors
 
@@ -26,6 +46,13 @@ pub struct CheckConfig {
 }
 pub fn CheckConfig::new(Int, Int, UInt64, Int) -> Self
 pub impl Default for CheckConfig
+
+pub struct CheckResult[T] {
+  passed : Bool
+  failure : Failure?
+  stats : Statistics?
+}
+pub impl[T : Show] Show for CheckResult[T]
 
 pub struct Failure {
   case_index : Int
@@ -50,6 +77,23 @@ pub fn[T] Gen::one_of(Array[Self[T]]) -> Self[T]
 pub fn[T] Gen::pure(T) -> Self[T]
 pub fn[T] Gen::resize(Self[T], Int) -> Self[T]
 pub fn[T] Gen::sized((Int) -> Self[T]) -> Self[T]
+
+pub struct StatEntry {
+  label : String
+  count : Int
+  percentage : Double
+}
+pub impl Show for StatEntry
+
+pub struct Statistics {
+  entries : Array[StatEntry]
+  mut total : Int
+}
+pub fn Statistics::add_label(Self, String) -> Unit
+pub fn Statistics::finalize(Self) -> Unit
+pub fn Statistics::new() -> Self
+pub fn Statistics::to_string(Self) -> String
+pub impl Show for Statistics
 
 // Type aliases
 

--- a/src/pbt/shrink.mbt
+++ b/src/pbt/shrink.mbt
@@ -27,3 +27,220 @@ pub fn[T] shrink_array(values : Array[T]) -> Iter[Array[T]] {
   candidates.push([])
   candidates.iter()
 }
+
+///|
+/// 文字列のshrink
+/// 空文字列に向けて縮小し、部分文字列を試す
+pub fn shrink_string(s : String) -> Iter[String] {
+  if s == "" {
+    return [].iter()
+  }
+  let candidates : Array[String] = []
+  let chars = s.to_array()
+  let len = chars.length()
+
+  // 空文字列を最初に試す
+  candidates.push("")
+
+  // 長さを半分ずつにする
+  let mut n = len / 2
+  while n > 0 {
+    let mut result = ""
+    let mut i = 0
+    while i < n {
+      result = result + chars[i].to_string()
+      i = i + 1
+    }
+    candidates.push(result)
+    n = n / 2
+  }
+
+  // 各文字を削除した文字列
+  let mut i = 0
+  while i < len && i < 10 {
+    // 最初の10文字だけ試す
+    let mut result = ""
+    let mut j = 0
+    while j < len {
+      if j != i {
+        result = result + chars[j].to_string()
+      }
+      j = j + 1
+    }
+    candidates.push(result)
+    i = i + 1
+  }
+  candidates.iter()
+}
+
+///|
+/// タプルのshrink
+/// 両方の要素をshrinkし、それぞれを固定してもう一方をshrinkする
+pub fn[A, B] shrink_tuple2(
+  t : (A, B),
+  shrink_a : (A) -> Iter[A],
+  shrink_b : (B) -> Iter[B],
+) -> Iter[(A, B)] {
+  let (a, b) = t
+  let candidates : Array[(A, B)] = []
+
+  // aをshrinkしてbを固定
+  for a_shrunk in shrink_a(a) {
+    candidates.push((a_shrunk, b))
+  }
+
+  // bをshrinkしてaを固定
+  for b_shrunk in shrink_b(b) {
+    candidates.push((a, b_shrunk))
+  }
+  candidates.iter()
+}
+
+///|
+/// Optionのshrink
+/// Some(x)をNoneに縮小し、Some(x)の中身もshrinkする
+pub fn[T] shrink_option(opt : T?, shrink_t : (T) -> Iter[T]) -> Iter[T?] {
+  match opt {
+    None => [].iter()
+    Some(value) => {
+      let candidates : Array[T?] = []
+      // Noneを最初に試す
+      candidates.push(None)
+      // 中身をshrinkする
+      for v in shrink_t(value) {
+        candidates.push(Some(v))
+      }
+      candidates.iter()
+    }
+  }
+}
+
+///|
+/// Double のshrink
+/// 0に向けて縮小する
+pub fn shrink_double(x : Double) -> Iter[Double] {
+  if x == 0.0 {
+    return [].iter()
+  }
+  let candidates : Array[Double] = [0.0]
+  let mut current = x / 2.0
+  let mut count = 0
+  while current.abs() > 0.001 && count < 10 {
+    candidates.push(current)
+    current = current / 2.0
+    count = count + 1
+  }
+  candidates.iter()
+}
+
+///|
+/// Bool のshrink
+/// trueをfalseに縮小する
+pub fn shrink_bool(b : Bool) -> Iter[Bool] {
+  if b {
+    [false].iter()
+  } else {
+    [].iter()
+  }
+}
+
+///|
+/// Shrinkテンプレートを生成（コード生成用）
+pub fn generate_shrink_template(
+  type_name : String,
+  fields : Array[(String, String)],
+) -> String {
+  let mut result = "fn shrink_" +
+    type_name.to_lower() +
+    "(value : " +
+    type_name +
+    ") -> Iter[" +
+    type_name +
+    "] {\n"
+  result = result + "  let candidates : Array[" + type_name + "] = []\n"
+
+  // 各フィールドをshrinkしてcandidatesに追加
+  let mut i = 0
+  while i < fields.length() {
+    let (field_name, field_type) = fields[i]
+    let shrinker = match field_type {
+      "Int" => "shrink_int"
+      "String" => "shrink_string"
+      "Bool" => "shrink_bool"
+      "Double" => "shrink_double"
+      _ => "shrink_" + field_type.to_lower()
+    }
+    result = result +
+      "  for v in " +
+      shrinker +
+      "(value." +
+      field_name +
+      ") {\n"
+    result = result + "    candidates.push({ .." + field_name + ": v })\n"
+    result = result + "  }\n"
+    i = i + 1
+  }
+  result = result + "  candidates.iter()\n"
+  result = result + "}\n"
+  result
+}
+
+///|
+fn string_to_lower(s : String) -> String {
+  let chars = s.to_array()
+  let mut result = ""
+  let mut i = 0
+  while i < chars.length() {
+    let c = chars[i]
+    let code = c.to_int()
+    if code >= 65 && code <= 90 {
+      result = result + Int::unsafe_to_char(code + 32).to_string()
+    } else {
+      result = result + c.to_string()
+    }
+    i = i + 1
+  }
+  result
+}
+
+///|
+test "shrink_string_empty" {
+  let result = shrink_string("")
+  inspect(result.count(), content="0")
+}
+
+///|
+test "shrink_string_nonempty" {
+  let result = shrink_string("hello")
+  let arr = result.to_array()
+  inspect(arr.length() > 0, content="true")
+  inspect(arr.contains(""), content="true")
+}
+
+///|
+test "shrink_option_none" {
+  let result = shrink_option((None : Int?), shrink_int)
+  inspect(result.count(), content="0")
+}
+
+///|
+test "shrink_option_some" {
+  let result = shrink_option(Some(10), shrink_int)
+  let arr = result.to_array()
+  inspect(arr.length() > 0, content="true")
+  inspect(arr.contains(None), content="true")
+}
+
+///|
+test "shrink_bool_true" {
+  let result = shrink_bool(true)
+  let arr = result.to_array()
+  inspect(arr.length(), content="1")
+  inspect(arr[0], content="false")
+}
+
+///|
+test "shrink_bool_false" {
+  let result = shrink_bool(false)
+  inspect(result.count(), content="0")
+}

--- a/src/state_machine/pkg.generated.mbti
+++ b/src/state_machine/pkg.generated.mbti
@@ -10,6 +10,12 @@ pub fn execute_commands(StateMachine, String) -> ExecutionResult
 
 pub fn generate_state_machine_test(StateMachine, String) -> String
 
+pub fn generate_state_machine_test_template(String, String, String, String) -> String
+
+pub fn[S : Show, Cmd : Show, R, Sh : Shim] run_state_machine_test(StateM[S, Cmd, R], Array[Cmd], (Cmd, Sh) -> R, Sh) -> StateMResult
+
+pub fn[T] shim_wrap(T, Unit) -> T
+
 // Errors
 
 // Types and methods
@@ -25,6 +31,36 @@ pub struct ExecutionResult {
   error_message : String
 }
 
+pub struct PassthroughShim {
+}
+pub fn PassthroughShim::new() -> Self
+pub impl Shim for PassthroughShim
+
+pub struct RecordingShim {
+  recorded : Array[String]
+}
+pub fn RecordingShim::new() -> Self
+pub impl Shim for RecordingShim
+
+pub struct StateM[S, Cmd, R] {
+  name : String
+  initial_state : S
+  next_state : (S, Cmd) -> S
+  precondition : (S, Cmd) -> Bool
+  postcondition : (S, Cmd, R) -> Bool
+}
+pub fn[S, Cmd, R] StateM::new(String, S, (S, Cmd) -> S) -> Self[S, Cmd, R]
+pub fn[S, Cmd, R] StateM::with_postcondition(Self[S, Cmd, R], (S, Cmd, R) -> Bool) -> Self[S, Cmd, R]
+pub fn[S, Cmd, R] StateM::with_precondition(Self[S, Cmd, R], (S, Cmd) -> Bool) -> Self[S, Cmd, R]
+
+pub struct StateMResult {
+  success : Bool
+  commands_executed : Int
+  final_state_desc : String
+  error_message : String?
+  effects : Array[String]
+}
+
 pub struct StateMachine {
   name : String
   initial_state : String
@@ -34,4 +70,8 @@ pub struct StateMachine {
 // Type aliases
 
 // Traits
+pub trait Shim {
+  record(Self, String) -> Unit
+  effects(Self) -> Array[String]
+}
 

--- a/src/state_machine/state_machine.mbt
+++ b/src/state_machine/state_machine.mbt
@@ -4,7 +4,245 @@
 ///
 
 ///|
-/// 状態マシンモデル
+/// Shim インターフェース
+/// テスト時に副作用を記録・制御するための抽象化
+pub trait Shim {
+  record(Self, String) -> Unit
+  effects(Self) -> Array[String]
+}
+
+///|
+/// パススルー Shim（何もしない）
+pub struct PassthroughShim {}
+
+///|
+pub fn PassthroughShim::new() -> PassthroughShim {
+  PassthroughShim::{  }
+}
+
+///|
+pub impl Shim for PassthroughShim with record(_self, _effect : String) -> Unit {
+
+}
+
+///|
+pub impl Shim for PassthroughShim with effects(_self) -> Array[String] {
+  []
+}
+
+///|
+/// 記録 Shim（副作用を記録する）
+pub struct RecordingShim {
+  recorded : Array[String]
+}
+
+///|
+pub fn RecordingShim::new() -> RecordingShim {
+  RecordingShim::{ recorded: [] }
+}
+
+///|
+pub impl Shim for RecordingShim with record(self, effect : String) -> Unit {
+  self.recorded.push(effect)
+}
+
+///|
+pub impl Shim for RecordingShim with effects(self) -> Array[String] {
+  self.recorded
+}
+
+///|
+/// 値をラップするユーティリティ（グローバル関数として提供）
+pub fn[T] shim_wrap(value : T, _shim : Unit) -> T {
+  value
+}
+
+///|
+/// 汎用状態マシンモデル
+pub struct StateM[S, Cmd, R] {
+  name : String
+  initial_state : S
+  next_state : (S, Cmd) -> S
+  precondition : (S, Cmd) -> Bool
+  postcondition : (S, Cmd, R) -> Bool
+}
+
+///|
+/// StateM コンストラクタ
+pub fn[S, Cmd, R] StateM::new(
+  name : String,
+  initial : S,
+  next : (S, Cmd) -> S,
+) -> StateM[S, Cmd, R] {
+  StateM::{
+    name,
+    initial_state: initial,
+    next_state: next,
+    precondition: fn(_s, _cmd) { true },
+    postcondition: fn(_s, _cmd, _r) { true },
+  }
+}
+
+///|
+/// 事前条件を設定
+pub fn[S, Cmd, R] StateM::with_precondition(
+  self : StateM[S, Cmd, R],
+  pre : (S, Cmd) -> Bool,
+) -> StateM[S, Cmd, R] {
+  StateM::{
+    name: self.name,
+    initial_state: self.initial_state,
+    next_state: self.next_state,
+    precondition: pre,
+    postcondition: self.postcondition,
+  }
+}
+
+///|
+/// 事後条件を設定
+pub fn[S, Cmd, R] StateM::with_postcondition(
+  self : StateM[S, Cmd, R],
+  post : (S, Cmd, R) -> Bool,
+) -> StateM[S, Cmd, R] {
+  StateM::{
+    name: self.name,
+    initial_state: self.initial_state,
+    next_state: self.next_state,
+    precondition: self.precondition,
+    postcondition: post,
+  }
+}
+
+///|
+/// 状態マシンテストの結果
+pub struct StateMResult {
+  success : Bool
+  commands_executed : Int
+  final_state_desc : String
+  error_message : String?
+  effects : Array[String]
+}
+
+///|
+/// 状態マシンテストを実行
+pub fn[S : Show, Cmd : Show, R, Sh : Shim] run_state_machine_test(
+  sm : StateM[S, Cmd, R],
+  commands : Array[Cmd],
+  execute : (Cmd, Sh) -> R,
+  shim : Sh,
+) -> StateMResult {
+  let mut state = sm.initial_state
+  let mut executed = 0
+  for cmd in commands {
+    // 事前条件チェック
+    if not((sm.precondition)(state, cmd)) {
+      continue
+    }
+
+    // コマンド実行
+    let result = execute(cmd, shim)
+    executed = executed + 1
+
+    // 事後条件チェック
+    if not((sm.postcondition)(state, cmd, result)) {
+      return StateMResult::{
+        success: false,
+        commands_executed: executed,
+        final_state_desc: "\{state}",
+        error_message: Some("Postcondition failed for command: \{cmd}"),
+        effects: shim.effects(),
+      }
+    }
+
+    // 状態遷移
+    state = (sm.next_state)(state, cmd)
+  }
+  StateMResult::{
+    success: true,
+    commands_executed: executed,
+    final_state_desc: "\{state}",
+    error_message: None,
+    effects: shim.effects(),
+  }
+}
+
+///|
+/// 状態マシンテストテンプレートを生成
+pub fn generate_state_machine_test_template(
+  name : String,
+  state_type : String,
+  cmd_type : String,
+  result_type : String,
+) -> String {
+  let mut code = "// State machine test for " + name + "\n\n"
+
+  // 状態型定義
+  code = code + "pub struct " + state_type + " {\n"
+  code = code + "  // TODO: Add state fields\n"
+  code = code + "}\n\n"
+
+  // コマンド型定義
+  code = code + "pub enum " + cmd_type + " {\n"
+  code = code + "  // TODO: Add command variants\n"
+  code = code + "}\n\n"
+
+  // 状態マシン定義
+  code = code +
+    "fn create_" +
+    string_to_lower(name) +
+    "_sm() -> @state_machine.StateM[" +
+    state_type +
+    ", " +
+    cmd_type +
+    ", " +
+    result_type +
+    "] {\n"
+  code = code + "  @state_machine.StateM::new(\n"
+  code = code + "    \"" + name + "\",\n"
+  code = code + "    " + state_type + "::{ /* initial state */ },\n"
+  code = code +
+    "    fn(state, cmd) { state }, // TODO: Implement state transition\n"
+  code = code + "  )\n"
+  code = code + "  .with_precondition(fn(state, cmd) { true })\n"
+  code = code + "  .with_postcondition(fn(state, cmd, result) { true })\n"
+  code = code + "}\n\n"
+
+  // テスト関数
+  code = code + "test \"" + name + "_state_machine\" {\n"
+  code = code + "  let sm = create_" + string_to_lower(name) + "_sm()\n"
+  code = code + "  let commands : Array[" + cmd_type + "] = []\n"
+  code = code + "  let shim = @state_machine.RecordingShim::new()\n"
+  code = code + "  let result = @state_machine.run_state_machine_test(\n"
+  code = code + "    sm,\n"
+  code = code + "    commands,\n"
+  code = code + "    fn(cmd, shim) { /* execute */ },\n"
+  code = code + "    shim,\n"
+  code = code + "  )\n"
+  code = code + "  assert_true(result.success)\n"
+  code = code + "}\n"
+  code
+}
+
+///|
+fn string_to_lower(s : String) -> String {
+  let chars = s.to_array()
+  let mut result = ""
+  let mut i = 0
+  while i < chars.length() {
+    let c = chars[i]
+    let code = c.to_int()
+    if code >= 65 && code <= 90 {
+      result = result + Int::unsafe_to_char(code + 32).to_string()
+    } else {
+      result = result + c.to_string()
+    }
+    i = i + 1
+  }
+  result
+}
+
+///|
+/// 状態マシンモデル（レガシー）
 pub struct StateMachine {
   name : String
   initial_state : String
@@ -120,4 +358,75 @@ test "int_to_string_converts" {
   inspect(int_to_string(0), content="0")
   inspect(int_to_string(3), content="3")
   inspect(int_to_string(5), content="5")
+}
+
+///|
+test "passthrough_shim_wraps" {
+  let shim = PassthroughShim::new()
+  let value = 42
+  let result = shim_wrap(value, ())
+  inspect(result, content="42")
+}
+
+///|
+test "passthrough_shim_no_effects" {
+  let shim = PassthroughShim::new()
+  shim.record("effect1")
+  let effects = shim.effects()
+  inspect(effects.length(), content="0")
+}
+
+///|
+test "recording_shim_records" {
+  let shim = RecordingShim::new()
+  shim.record("effect1")
+  shim.record("effect2")
+  let effects = shim.effects()
+  inspect(effects.length(), content="2")
+  inspect(effects[0], content="effect1")
+  inspect(effects[1], content="effect2")
+}
+
+///|
+test "state_m_construction" {
+  let sm = StateM::new("TestSM", 0, fn(s, _cmd) { s })
+  inspect(sm.name, content="TestSM")
+  inspect(sm.initial_state, content="0")
+}
+
+///|
+test "state_m_with_precondition" {
+  let sm = StateM::new("TestSM", 0, fn(s, cmd) { s + cmd }).with_precondition(fn(
+    s,
+    cmd,
+  ) {
+    s + cmd < 10
+  })
+  // 事前条件が設定されていることを確認
+  let ok = (sm.precondition)(5, 3)
+  inspect(ok, content="true")
+}
+
+///|
+test "state_m_with_postcondition" {
+  let sm = StateM::new("TestSM", 0, fn(s, cmd) { s + cmd }).with_postcondition(fn(
+    _s,
+    _cmd,
+    _r,
+  ) {
+    true
+  })
+  // 事後条件が設定されていることを確認
+  let ok = (sm.postcondition)(0, 1, 1)
+  inspect(ok, content="true")
+}
+
+///|
+test "generate_state_machine_test_template" {
+  let template = generate_state_machine_test_template(
+    "Queue", "QueueState", "QueueCmd", "Unit",
+  )
+  inspect(template.contains("State machine test for Queue"), content="true")
+  inspect(template.contains("pub struct QueueState"), content="true")
+  inspect(template.contains("pub enum QueueCmd"), content="true")
 }


### PR DESCRIPTION
## 概要

Issue #30 (Aletheia PBT 改善実装) の各Phase (#24-#29) を実装しました。

## 変更内容

### Phase 1: パターン検出の拡張 (#24)
- `Invariant`, `Oracle` パターン候補を追加
- 不変条件検出: `find_invariant_functions()`
- オラクル検出: `find_oracle_candidates()`

### Phase 2: 統計収集機能の追加 (#25)
- `StatEntry`, `Statistics`, `CheckResult[T]` 構造体
- `classify()`, `collect()` 関数
- `check_with_stats()` 関数

### Phase 3: テンプレート生成の拡張 (#26)
- Invariant/Oracle テスト生成
- 統計付きテスト生成
- Markdown出力の拡張

### Phase 4: Shrinkingサポートの強化 (#27)
- `shrink_string()`, `shrink_tuple2()`, `shrink_option()`
- `shrink_double()`, `shrink_bool()`
- Shrinkテンプレート生成

### Phase 5: State Machineの強化 (#28)
- `Shim` トレイト
- `PassthroughShim`, `RecordingShim`
- 汎用 `StateM[S, Cmd, R]` モデル
- `run_state_machine_test()` 関数

### Phase 6: CLI統合 (#29)
- `PackageAnalysis` への新パターン統合
- analyze/describe/json出力の拡張
- 生成レポートへの反映

## テスト結果

```
Total tests: 141, passed: 140, failed: 1
```

失敗したテストは生成ファイルの日付に関連するもので、本実装とは無関係です。

## 関連Issue

Closes #30 #24 #25 #26 #27 #28 #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)